### PR TITLE
Enhance install script for sync-tokens with interactive prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,14 +236,14 @@ KIMI_API_KEY_FILE=/run/secrets/kimi_api_key
 3. From your macOS machine, install the launchd sync daemon:
 
 ```bash
-# install
-./scripts/install_launchd.sh
+# install (interactive — prompts for repo path, Pi SSH host, secrets dir)
+bash <(curl -fsSL https://raw.githubusercontent.com/palemoky/paper-pi/main/scripts/install_launchd.sh)
 
 # view logs
 tail -f /tmp/sync_ai_tokens.log
 
 # uninstall
-./scripts/install_launchd.sh uninstall
+bash <(curl -fsSL https://raw.githubusercontent.com/palemoky/paper-pi/main/scripts/install_launchd.sh) uninstall
 ```
 
 > **Note**

--- a/scripts/com.paper-pi.sync-tokens.plist
+++ b/scripts/com.paper-pi.sync-tokens.plist
@@ -25,9 +25,9 @@
   <key>EnvironmentVariables</key>
   <dict>
     <key>PI_TARGET</key>
-    <string>pi</string>
+    <string>__PI_TARGET__</string>
     <key>PI_SECRETS_DIR</key>
-    <string>/home/pi/paper-pi/secrets</string>
+    <string>__PI_SECRETS_DIR__</string>
     <key>PATH</key>
     <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
   </dict>

--- a/scripts/install_launchd.sh
+++ b/scripts/install_launchd.sh
@@ -3,9 +3,13 @@ set -euo pipefail
 
 # Install (or update) the sync-tokens LaunchAgent from the plist template.
 #
-# Usage:
-#   ./scripts/install_launchd.sh            # install / update
-#   ./scripts/install_launchd.sh uninstall  # remove
+# Usage (remote):
+#   bash <(curl -fsSL https://raw.githubusercontent.com/palemoky/paper-pi/main/scripts/install_launchd.sh)
+#   bash <(curl -fsSL https://raw.githubusercontent.com/palemoky/paper-pi/main/scripts/install_launchd.sh) uninstall
+#
+# Usage (local):
+#   ./scripts/install_launchd.sh
+#   ./scripts/install_launchd.sh uninstall
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "Error: this script only works on macOS (launchd). Current OS: $(uname -s)" >&2
@@ -13,9 +17,11 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
 fi
 
 LABEL="com.paper-pi.sync-tokens"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-TEMPLATE="$SCRIPT_DIR/com.paper-pi.sync-tokens.plist"
 DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+# Detect local run: script is a real file with the plist template alongside it
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOCAL_TEMPLATE="$SCRIPT_DIR/com.paper-pi.sync-tokens.plist"
 
 uninstall() {
   if launchctl list "$LABEL" &>/dev/null; then
@@ -29,25 +35,88 @@ uninstall() {
   echo "Done."
 }
 
-install() {
-  if [[ ! -f "$TEMPLATE" ]]; then
-    echo "Error: template not found at $TEMPLATE" >&2
-    exit 1
+prompt() {
+  local var_name="$1" prompt_text="$2" default="$3"
+  read -rp "$prompt_text [$default]: " input
+  printf -v "$var_name" '%s' "${input:-$default}"
+}
+
+render_plist() {
+  local script_dir="$1" pi_target="$2" pi_secrets_dir="$3"
+  local template_path="$LOCAL_TEMPLATE"
+
+  if [[ ! -f "$template_path" ]]; then
+    template_path="$script_dir/$PLIST_TEMPLATE"
   fi
 
-  # Replace placeholder with actual path
-  mkdir -p "$HOME/Library/LaunchAgents"
-  sed "s|__SCRIPT_DIR__|$SCRIPT_DIR|g" "$TEMPLATE" > "$DEST"
+  if [[ ! -f "$template_path" ]]; then
+    echo "Error: plist template not found at $template_path" >&2
+    return 1
+  fi
 
-  # Reload if already loaded
+  sed \
+    -e "s|__SCRIPT_DIR__|$script_dir|g" \
+    -e "s|__PI_TARGET__|$pi_target|g" \
+    -e "s|__PI_SECRETS_DIR__|$pi_secrets_dir|g" \
+    "$template_path"
+}
+
+GITHUB_RAW="https://raw.githubusercontent.com/palemoky/paper-pi/main"
+SYNC_SCRIPT="sync_ai_tokens_to_pi.py"
+PLIST_TEMPLATE="com.paper-pi.sync-tokens.plist"
+
+fetch_sync_script() {
+  local dest_dir="$1"
+  local dest="$dest_dir/$SYNC_SCRIPT"
+  if [[ -f "$dest" ]]; then
+    echo "  $SYNC_SCRIPT already exists, skipping download."
+    return
+  fi
+  echo "  Downloading $SYNC_SCRIPT..."
+  mkdir -p "$dest_dir"
+  curl -fsSL "$GITHUB_RAW/scripts/$SYNC_SCRIPT" -o "$dest"
+  chmod +x "$dest"
+  echo "  Saved to $dest"
+}
+
+fetch_plist_template() {
+  local dest_dir="$1"
+  local dest="$dest_dir/$PLIST_TEMPLATE"
+  if [[ -f "$dest" ]]; then
+    echo "  $PLIST_TEMPLATE already exists, skipping download."
+    return
+  fi
+  echo "  Downloading $PLIST_TEMPLATE..."
+  mkdir -p "$dest_dir"
+  curl -fsSL "$GITHUB_RAW/scripts/$PLIST_TEMPLATE" -o "$dest"
+  echo "  Saved to $dest"
+}
+
+install() {
+  echo "Configure sync-tokens LaunchAgent:"
+  prompt REPO_DIR       "  Local repo path" "$HOME/.paper-pi"
+  prompt PI_TARGET      "  Pi SSH host"     "pi"
+  prompt PI_SECRETS_DIR "  Secrets dir on Pi" "/home/pi/paper-pi/secrets"
+  echo ""
+
+  # Download sync script when not running from a local clone
+  if [[ ! -f "$LOCAL_TEMPLATE" ]]; then
+    fetch_sync_script "$REPO_DIR/scripts"
+    fetch_plist_template "$REPO_DIR/scripts"
+    echo ""
+  fi
+
+  mkdir -p "$HOME/Library/LaunchAgents"
+  render_plist "$REPO_DIR/scripts" "$PI_TARGET" "$PI_SECRETS_DIR" > "$DEST"
+
   if launchctl list "$LABEL" &>/dev/null; then
     launchctl unload "$DEST" 2>/dev/null || true
   fi
 
   launchctl load "$DEST"
   echo "Installed and loaded $LABEL"
-  echo "  Plist: $DEST"
-  echo "  Script: $SCRIPT_DIR/sync_ai_tokens_to_pi.py"
+  echo "  Plist:  $DEST"
+  echo "  Script: $REPO_DIR/scripts/sync_ai_tokens_to_pi.py"
   echo ""
   echo "View logs:  tail -f /tmp/sync_ai_tokens.log"
 }

--- a/src/layouts/components/footer.py
+++ b/src/layouts/components/footer.py
@@ -169,14 +169,13 @@ class FooterComponent:
             text_x = center_x + (x_sign * offset_x)
             text_y = self.FOOTER_CENTER_Y + (y_sign * offset_y)
             text_value = normalized_value[position_name]
-            text_font = r.font_commits if y_sign < 0 else r.font_xs
 
             r.draw_centered_text(
                 draw,
                 text_x,
                 text_y,
                 text_value,
-                font=text_font,
+                font=r.font_cross,
                 align_y_center=True,
             )
 

--- a/src/providers/ai_usage.py
+++ b/src/providers/ai_usage.py
@@ -49,15 +49,21 @@ def _read_secret_token(file_path: str) -> str:
     return ""
 
 
-def _resolve_token(provider_name: str, file_path: str, env_token: str) -> str:
-    """Resolve token by preferring mounted secret file over env var."""
-    token = _read_secret_token(file_path) or (env_token or "").strip()
+def _resolve_token(provider_name: str, file_path: str, env_token: str) -> tuple[str, bool]:
+    """Resolve token by preferring mounted secret file over env var.
+
+    Returns (token, is_configured). is_configured is True when a raw token exists
+    in the file or env, even if that token is currently marked invalid.
+    """
+    raw = _read_secret_token(file_path) or (env_token or "").strip()
+    if not raw:
+        return "", False
 
     invalid_token = _INVALID_TOKEN_BY_PROVIDER.get(provider_name)
-    if token and invalid_token and token == invalid_token:
-        # Token already known as invalid/expired; wait for macOS sync to rotate it.
-        return ""
-    return token
+    if invalid_token and raw == invalid_token:
+        return "", True
+
+    return raw, True
 
 
 def _mark_invalid_token(provider_name: str, token: str) -> None:
@@ -86,13 +92,13 @@ async def get_claude_usage(client: httpx.AsyncClient) -> dict[str, int | str] | 
             "weekly_reset": str,
         } or None when token is not configured.
     """
-    token = _resolve_token(
+    token, is_configured = _resolve_token(
         "Claude",
         Config.api.claude_oauth_token_file,
         Config.api.claude_oauth_token,
     )
     if not token:
-        return None
+        return _fallback_usage("Claude") if is_configured else None
 
     headers = {
         "Authorization": f"Bearer {token}",
@@ -146,13 +152,13 @@ async def get_chatgpt_usage(client: httpx.AsyncClient) -> dict[str, int | str] |
             "weekly_reset": str,
         } or None when token is not configured.
     """
-    token = _resolve_token(
+    token, is_configured = _resolve_token(
         "ChatGPT",
         Config.api.chatgpt_oauth_token_file,
         Config.api.chatgpt_oauth_token,
     )
     if not token:
-        return None
+        return _fallback_usage("ChatGPT") if is_configured else None
 
     base_url = _normalize_chatgpt_base_url(Config.api.chatgpt_base_url)
     url = f"{base_url}{CHATGPT_USAGE_PATH}"
@@ -203,13 +209,13 @@ async def get_chatgpt_usage(client: httpx.AsyncClient) -> dict[str, int | str] |
 @cached(ttl=300)  # Cache for 5 minutes
 async def get_kimi_usage(client: httpx.AsyncClient) -> dict[str, int | str] | None:
     """Fetch Kimi Code usage from /usages endpoint."""
-    api_key = _resolve_token(
+    api_key, is_configured = _resolve_token(
         "Kimi",
         Config.api.kimi_api_key_file,
         Config.api.kimi_api_key,
     )
     if not api_key:
-        return None
+        return _fallback_usage("Kimi") if is_configured else None
 
     base_url = (Config.api.kimi_base_url or "https://api.kimi.com/coding/v1").strip().rstrip("/")
     url = f"{base_url}{KIMI_USAGE_PATH}"

--- a/src/providers/ai_usage.py
+++ b/src/providers/ai_usage.py
@@ -92,7 +92,7 @@ async def get_claude_usage(client: httpx.AsyncClient) -> dict[str, int | str] | 
         Config.api.claude_oauth_token,
     )
     if not token:
-        return _fallback_usage("Claude")
+        return None
 
     headers = {
         "Authorization": f"Bearer {token}",
@@ -152,7 +152,7 @@ async def get_chatgpt_usage(client: httpx.AsyncClient) -> dict[str, int | str] |
         Config.api.chatgpt_oauth_token,
     )
     if not token:
-        return _fallback_usage("ChatGPT")
+        return None
 
     base_url = _normalize_chatgpt_base_url(Config.api.chatgpt_base_url)
     url = f"{base_url}{CHATGPT_USAGE_PATH}"
@@ -209,7 +209,7 @@ async def get_kimi_usage(client: httpx.AsyncClient) -> dict[str, int | str] | No
         Config.api.kimi_api_key,
     )
     if not api_key:
-        return _fallback_usage("Kimi")
+        return None
 
     base_url = (Config.api.kimi_base_url or "https://api.kimi.com/coding/v1").strip().rstrip("/")
     url = f"{base_url}{KIMI_USAGE_PATH}"

--- a/src/renderer/dashboard.py
+++ b/src/renderer/dashboard.py
@@ -62,7 +62,7 @@ class DashboardRenderer:
             self.font_value = ImageFont.truetype(font_path, 32)
             self.font_date_big = ImageFont.truetype(font_path, 34)
             self.font_date_small = ImageFont.truetype(font_path, 24)
-            self.font_commits = ImageFont.truetype(font_path, 20)
+            self.font_cross = ImageFont.truetype(font_path, 20)
             self.font_l = ImageFont.truetype(font_path, 48)
             self.font_xl = ImageFont.truetype(font_path, 60)
             logger.debug(f"Loaded fonts from {font_path}")
@@ -74,7 +74,7 @@ class DashboardRenderer:
             self.font_xs = self.font_value = self.font_date_big = self.font_date_small = (
                 default_font
             )
-            self.font_commits = default_font
+            self.font_cross = default_font
 
     # Convenience methods that delegate to component renderers
 


### PR DESCRIPTION
This pull request updates the installation process for the sync-tokens LaunchAgent to support remote, one-command installation and interactive configuration. It introduces template rendering for the launchd plist, parameterizes environment variables, and improves usage documentation.

**Installation and configuration improvements:**

* The install script (`install_launchd.sh`) now supports remote installation via a single bash command, with interactive prompts for local repo path, Pi SSH host, and secrets directory. [[1]](diffhunk://#diff-a18300ac8e4b8f297180573980a5617dd8fb8710a3fa97ea2eb35506a1f3d619L6-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L239-R246)
* The script renders the launchd plist from a template, replacing placeholders with user-provided values, and downloads required files if not running from a local clone.

**Template and environment variable changes:**

* The `com.paper-pi.sync-tokens.plist` template now uses placeholders (`__PI_TARGET__`, `__PI_SECRETS_DIR__`) for environment variables, which are populated during installation.

**Documentation updates:**

* The `README.md` has been updated to reflect the new installation method, emphasizing the interactive, remote-friendly approach.